### PR TITLE
[ic_resource_group] Fix module parameter call

### DIFF
--- a/plugins/modules/ic_resource_group.py
+++ b/plugins/modules/ic_resource_group.py
@@ -102,7 +102,7 @@ def run_module():
             module.exit_json(changed=False, msg=check)
 
         result = resource.create_group(
-            group=group,
+            name=group,
             account_id=account_id
         )
 


### PR DESCRIPTION
The module fails to create the resource group.

When a module creates a resource group, it calls a "create_group" method from the "ibmcloud-python-sdk".
The "create_group" method has a "name" argument while the module uses "group" parameter to define the resource group name.

Modify the argument while calling the "create_group" method from the module, to be able to create the resource group.